### PR TITLE
Add ASCII playback helper for Edge Skate sessions

### DIFF
--- a/edge_skate/__init__.py
+++ b/edge_skate/__init__.py
@@ -1,5 +1,5 @@
 """EdgeSkate package implementing README-described pipeline."""
 
-from .pipeline import EdgeSkatePipeline, PipelineConfig
+from .pipeline import EdgeSkatePipeline, PipelineConfig, SessionArtifacts
 
-__all__ = ["EdgeSkatePipeline", "PipelineConfig"]
+__all__ = ["EdgeSkatePipeline", "PipelineConfig", "SessionArtifacts"]

--- a/edge_skate/player.py
+++ b/edge_skate/player.py
@@ -1,0 +1,89 @@
+"""Simple ASCII player for EdgeSkate sessions."""
+from __future__ import annotations
+
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, TextIO
+
+from .pipeline import EdgeSkatePipeline, PipelineConfig, SessionArtifacts
+from .physics import TrickEvent
+from .rendering import render_overlay
+
+
+@dataclass
+class PlaybackFrame:
+    """Represents a single playback step."""
+
+    index: int
+    overlay: str
+    velocity: float | None = None
+    trick_event: TrickEvent | None = None
+
+
+def iter_playback_frames(artifacts: SessionArtifacts) -> Iterator[PlaybackFrame]:
+    """Yield ASCII overlays to animate the simulated run."""
+
+    path = artifacts.simulation.path
+    if not path:
+        yield PlaybackFrame(index=0, overlay=render_overlay(artifacts.processed_frame, []))
+        return
+
+    trick_lookup = {event.frame: event for event in artifacts.simulation.trick_events}
+    velocities = artifacts.simulation.velocities
+    for idx in range(1, len(path) + 1):
+        segment = path[:idx]
+        overlay = render_overlay(artifacts.processed_frame, segment)
+        velocity = None
+        if velocities:
+            velocity = velocities[min(idx - 1, len(velocities) - 1)]
+        yield PlaybackFrame(
+            index=idx,
+            overlay=overlay,
+            velocity=velocity,
+            trick_event=trick_lookup.get(idx),
+        )
+
+
+def play(
+    source: Path,
+    *,
+    config: PipelineConfig | None = None,
+    frame_delay: float = 0.15,
+    stream: TextIO | None = None,
+    clear_between_frames: bool = True,
+) -> SessionArtifacts:
+    """Run the pipeline for a source and stream a simple ASCII playback."""
+
+    pipeline = EdgeSkatePipeline(config)
+    artifacts = pipeline.create_session(source)
+    target_stream = stream or sys.stdout
+
+    for frame in iter_playback_frames(artifacts):
+        _write_frame(target_stream, frame, clear_between_frames)
+        _sleep_for_frame(frame_delay, frame.velocity)
+
+    return artifacts
+
+
+def _write_frame(stream: TextIO, frame: PlaybackFrame, clear: bool) -> None:
+    if clear:
+        stream.write("\x1b[2J\x1b[H")
+    stream.write(frame.overlay)
+    stream.write("\n")
+    if frame.velocity is not None:
+        stream.write(f"velocity: {frame.velocity:.2f}\n")
+    if frame.trick_event:
+        stream.write(f"trick: {frame.trick_event.name} (frame {frame.trick_event.frame})\n")
+    stream.flush()
+
+
+def _sleep_for_frame(base_delay: float, velocity: float | None) -> None:
+    if base_delay <= 0:
+        return
+    delay = base_delay
+    if velocity and velocity > 0:
+        delay = base_delay / max(0.5, velocity)
+    time.sleep(delay)
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+from edge_skate.pipeline import EdgeSkatePipeline, PipelineConfig
+from edge_skate.player import iter_playback_frames, play
+
+
+def _build_pipeline(tmp_path: Path | None = None) -> EdgeSkatePipeline:
+    config = PipelineConfig(
+        target_resolution=(16, 16),
+        denoise_strength=0.2,
+        edge_threshold=0.2,
+        smoothing_factor=0.3,
+        base_speed=2.5,
+        trick_interval=5,
+        output_dir=tmp_path or Path("output"),
+    )
+    return EdgeSkatePipeline(config)
+
+
+def test_iter_playback_frames_matches_final_overlay(tmp_path: Path) -> None:
+    pipeline = _build_pipeline(tmp_path)
+    artifacts = pipeline.create_session(Path("samples/sample_frame.json"))
+    frames = list(iter_playback_frames(artifacts))
+    assert frames, "expected at least one playback frame"
+    assert frames[-1].overlay == artifacts.overlay
+
+
+def test_play_streams_ascii_without_sleep(tmp_path: Path) -> None:
+    pipeline = _build_pipeline(tmp_path)
+    stream = StringIO()
+    artifacts = play(
+        Path("samples/sample_frame.json"),
+        config=pipeline.config,
+        frame_delay=0,
+        stream=stream,
+        clear_between_frames=False,
+    )
+    output = stream.getvalue()
+    assert artifacts.overlay in output
+    assert "velocity:" in output


### PR DESCRIPTION
## Summary
- expose in-memory session artifacts from the pipeline for reuse
- add an ASCII playback helper that animates simulation results
- cover the new functionality with unit tests and configure pytest to import the package

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e605e68d5883268e1ea35622f852a7