### PR TITLE
Add SwiftUI iOS game start screen project

### DIFF
--- a/ios/GameStart/GameStart/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios/GameStart/GameStart/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal",
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "red" : "0.964",
+          "green" : "0.752",
+          "blue" : "0.325",
+          "alpha" : "1.0"
+        }
+      }
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ios/GameStart/GameStart/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/GameStart/GameStart/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/ios/GameStart/GameStart/Assets.xcassets/Contents.json
+++ b/ios/GameStart/GameStart/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios/GameStart/GameStart/GameStartApp.swift
+++ b/ios/GameStart/GameStart/GameStartApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct GameStartApp: App {
+    var body: some Scene {
+        WindowGroup {
+            StartScreen()
+        }
+    }
+}

--- a/ios/GameStart/GameStart/StartScreen.swift
+++ b/ios/GameStart/GameStart/StartScreen.swift
@@ -1,0 +1,116 @@
+import SwiftUI
+
+struct StartScreen: View {
+    @State private var isAnimating = false
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                gradient: Gradient(colors: [Color("AccentColor"), Color(red: 0.18, green: 0.2, blue: 0.45)]),
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 32) {
+                VStack(spacing: 12) {
+                    Text("Edge Quest")
+                        .font(.system(size: 48, weight: .heavy, design: .rounded))
+                        .foregroundStyle(.white)
+                        .shadow(color: .black.opacity(0.4), radius: 12, x: 0, y: 6)
+
+                    Text("Sharpen your skills and ride the perfect line")
+                        .font(.title3.weight(.medium))
+                        .multilineTextAlignment(.center)
+                        .foregroundStyle(.white.opacity(0.85))
+                        .padding(.horizontal, 32)
+                }
+
+                Spacer()
+
+                VStack(spacing: 20) {
+                    Button(action: startGame) {
+                        Text("Start Game")
+                            .font(.title2.weight(.bold))
+                            .padding(.vertical, 16)
+                            .padding(.horizontal, 64)
+                            .background(
+                                Capsule()
+                                    .fill(Color.white)
+                                    .shadow(color: .black.opacity(0.3), radius: 12, x: 0, y: 10)
+                            )
+                            .foregroundStyle(Color(red: 0.16, green: 0.21, blue: 0.4))
+                    }
+                    .scaleEffect(isAnimating ? 1.04 : 1.0)
+                    .animation(
+                        .easeInOut(duration: 1.4)
+                        .repeatForever(autoreverses: true),
+                        value: isAnimating
+                    )
+
+                    Button(action: openSettings) {
+                        Label("Settings", systemImage: "gearshape.fill")
+                            .font(.headline)
+                            .padding(.horizontal, 24)
+                            .padding(.vertical, 12)
+                            .background(
+                                Capsule()
+                                    .strokeBorder(Color.white.opacity(0.6), lineWidth: 1.5)
+                            )
+                            .foregroundStyle(Color.white.opacity(0.9))
+                    }
+                }
+
+                Spacer()
+
+                HStack(spacing: 16) {
+                    InfoPill(title: "Story Mode", subtitle: "Explore the frozen city")
+                    InfoPill(title: "Time Attack", subtitle: "Beat your best run")
+                }
+                .padding(.bottom, 32)
+                .padding(.horizontal, 16)
+            }
+            .padding(.top, 80)
+            .padding(.horizontal, 16)
+        }
+        .onAppear {
+            isAnimating = true
+        }
+    }
+
+    private func startGame() {
+        // TODO: Hook into navigation stack or coordinator.
+    }
+
+    private func openSettings() {
+        // TODO: Present settings sheet.
+    }
+}
+
+struct InfoPill: View {
+    let title: String
+    let subtitle: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(.white)
+            Text(subtitle)
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.8))
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(Color.white.opacity(0.18))
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                .stroke(Color.white.opacity(0.25), lineWidth: 1)
+        )
+    }
+}
+
+#Preview {
+    StartScreen()
+}

--- a/ios/GameStart/README.md
+++ b/ios/GameStart/README.md
@@ -1,0 +1,22 @@
+# GameStart iOS App
+
+This directory contains a minimal SwiftUI iOS application that displays a stylised game start screen for an imaginary title called **Edge Quest**.
+
+## Structure
+
+```
+GameStart/
+├── GameStartApp.swift        // Entry point for the SwiftUI app
+├── StartScreen.swift         // Main start screen view
+└── Assets.xcassets/          // Accent colour and placeholder app icon definitions
+```
+
+## Usage
+
+1. Open the `ios/GameStart` folder in Xcode.
+2. Create a new Xcode project (App template) named **GameStart**, targeting iOS 16 or later.
+3. Replace the generated SwiftUI files with the versions in this repository.
+4. Add the provided asset catalog items to your project's asset catalog.
+5. Run the app on the simulator to see the animated start screen with "Start Game" and "Settings" actions.
+
+The `startGame()` and `openSettings()` actions are marked with `TODO:` comments where navigation or presentation logic can be added.


### PR DESCRIPTION
## Summary
- add a SwiftUI-based iOS project stub for the Edge Quest game
- implement an animated start screen with primary and secondary actions
- provide asset catalog placeholders and usage instructions for integrating into Xcode

## Testing
- not run (iOS project files only)


------
https://chatgpt.com/codex/tasks/task_e_68e60899e8148326a7036388e4164c44